### PR TITLE
feat: Sidebar: display full tree and link to editor routes

### DIFF
--- a/packages/core/src/components/MainView.tsx
+++ b/packages/core/src/components/MainView.tsx
@@ -48,7 +48,7 @@ const MainView = ({
         <div
           id="main-view"
           className={classNames(
-            showLeftNav ? 'w-main left-64' : 'w-full',
+            showLeftNav ? 'w-main left-sidebar-expanded' : 'w-full',
             !noMargin && 'px-5 py-4',
             noScroll ? 'overflow-hidden' : 'overflow-y-auto',
             `

--- a/packages/core/src/components/entry-editor/Editor.tsx
+++ b/packages/core/src/components/entry-editor/Editor.tsx
@@ -308,7 +308,7 @@ const Editor: FC<TranslatedProps<EditorProps>> = ({
         <h3>{entry.error}</h3>
       </div>
     );
-  } else if (entryDraft == null || entryDraft?.entry === undefined || (entry && entry.isFetching)) {
+  } else if (entryDraft == null || entryDraft.entry === undefined || (entry && entry.isFetching)) {
     return <Loader>{t('editor.editor.loadingEntry')}</Loader>;
   }
 

--- a/packages/core/src/components/entry-editor/Editor.tsx
+++ b/packages/core/src/components/entry-editor/Editor.tsx
@@ -54,6 +54,7 @@ const Editor: FC<TranslatedProps<EditorProps>> = ({
   localBackup,
   scrollSyncActive,
   newRecord,
+  showLeftNav,
   t,
 }) => {
   const [version, setVersion] = useState(0);
@@ -307,7 +308,7 @@ const Editor: FC<TranslatedProps<EditorProps>> = ({
         <h3>{entry.error}</h3>
       </div>
     );
-  } else if (entryDraft == null || entryDraft.entry === undefined || (entry && entry.isFetching)) {
+  } else if (entryDraft == null || entryDraft?.entry === undefined || (entry && entry.isFetching)) {
     return <Loader>{t('editor.editor.loadingEntry')}</Loader>;
   }
 
@@ -332,6 +333,7 @@ const Editor: FC<TranslatedProps<EditorProps>> = ({
         loadScroll={handleLoadScroll}
         submitted={submitted}
         slug={slug}
+        showLeftNav={showLeftNav}
         t={t}
       />
       <MediaLibraryModal />
@@ -343,6 +345,7 @@ interface CollectionViewOwnProps {
   name: string;
   slug?: string;
   newRecord: boolean;
+  showLeftNav?: boolean;
 }
 
 function mapStateToProps(state: RootState, ownProps: CollectionViewOwnProps) {
@@ -360,6 +363,7 @@ function mapStateToProps(state: RootState, ownProps: CollectionViewOwnProps) {
   const draftKey = entryDraft.key;
   return {
     ...ownProps,
+    showLeftNav: !!ownProps.showLeftNav,
     collection,
     collections,
     entryDraft,

--- a/packages/core/src/components/entry-editor/EditorInterface.tsx
+++ b/packages/core/src/components/entry-editor/EditorInterface.tsx
@@ -73,6 +73,7 @@ interface EditorInterfaceProps {
   loadScroll: () => void;
   submitted: boolean;
   slug: string | undefined;
+  showLeftNav: boolean;
 }
 
 const EditorInterface = ({
@@ -94,6 +95,7 @@ const EditorInterface = ({
   toggleScroll,
   submitted,
   slug,
+  showLeftNav,
 }: TranslatedProps<EditorInterfaceProps>) => {
   const { locales, defaultLocale } = useMemo(() => getI18nInfo(collection), [collection]) ?? {};
   const translatedLocales = useMemo(
@@ -280,6 +282,7 @@ const EditorInterface = ({
         entry={previewEntry}
         fields={fields}
         editorSize={editorSize}
+        showLeftNav={showLeftNav}
       />
     </div>
   );
@@ -304,6 +307,7 @@ const EditorInterface = ({
     <MainView
       breadcrumbs={breadcrumbs}
       noMargin
+      showLeftNav={true}
       noScroll={finalPreviewActive || i18nActive}
       navbarActions={
         <EditorToolbar

--- a/packages/core/src/components/entry-editor/EditorRoute.tsx
+++ b/packages/core/src/components/entry-editor/EditorRoute.tsx
@@ -28,7 +28,7 @@ const EditorRoute = ({ newRecord = false, collections }: EditorRouteProps) => {
     return <Navigate to={defaultPath} />;
   }
 
-  return <Editor name={name} slug={slug} newRecord={newRecord} />;
+  return <Editor name={name} slug={slug} newRecord={newRecord} showLeftNav/>;
 };
 
 export default EditorRoute;

--- a/packages/core/src/components/entry-editor/editor-preview-pane/EditorPreviewPane.tsx
+++ b/packages/core/src/components/entry-editor/editor-preview-pane/EditorPreviewPane.tsx
@@ -107,10 +107,11 @@ export interface EditorPreviewPaneProps {
   entry: Entry;
   previewInFrame: boolean;
   editorSize: EditorSize;
+  showLeftNav?: boolean;
 }
 
 const PreviewPane = (props: TranslatedProps<EditorPreviewPaneProps>) => {
-  const { editorSize, entry, collection, fields, previewInFrame, t } = props;
+  const { editorSize, entry, collection, fields, previewInFrame, showLeftNav, t } = props;
 
   const config = useAppSelector(selectConfig);
 
@@ -171,6 +172,7 @@ const PreviewPane = (props: TranslatedProps<EditorPreviewPaneProps>) => {
       return null;
     }
 
+    const editorCompact = editorSize === EDITOR_SIZE_COMPACT;
     return createPortal(
       <div
         className={classNames(
@@ -180,7 +182,7 @@ const PreviewPane = (props: TranslatedProps<EditorPreviewPaneProps>) => {
             top-16
             right-0
           `,
-          editorSize === EDITOR_SIZE_COMPACT ? 'w-preview' : 'w-6/12',
+          showLeftNav ? (editorCompact ? 'w-preview-compact-sidebar' : 'w-preview-half-sidebar') : (editorCompact ? 'w-preview' : 'w-6/12'),
         )}
       >
         {!entry || !entry.data ? null : (

--- a/packages/core/src/lib/hooks/useBreadcrumbs.ts
+++ b/packages/core/src/lib/hooks/useBreadcrumbs.ts
@@ -5,6 +5,7 @@ import { useAppDispatch } from '@staticcms/core/store/hooks';
 import { selectEntryCollectionTitle, selectFolderEntryExtension } from '../util/collection.util';
 import { addFileTemplateFields } from '../widgets/stringTemplate';
 import useEntries from './useEntries';
+import {getTreeNodeIndexFile} from "@staticcms/core/lib/util/nested.util";
 
 import type { Breadcrumb, Collection, Entry } from '@staticcms/core/interface';
 import type { t } from 'react-polyglot';
@@ -65,9 +66,20 @@ export default function useBreadcrumbs(
             title = selectEntryCollectionTitle(collection, entry);
           }
 
+          const index = getTreeNodeIndexFile(collection, entry);
+
+          let to;
+          if (index) {
+            to = `/collections/${collection.name}/entries/${index.slug}`;
+          } else if (entry) {
+            to = `/collections/${collection.name}/entries/${entry.slug}`;
+          } else {
+            to = `/collections/${collection.name}/filter/${pathSoFar}`;
+          }
+
           crumbs.push({
             name: title,
-            to: `/collections/${collection.name}/filter/${pathSoFar}`,
+            to,
           });
         }
 

--- a/packages/core/src/lib/util/nested.util.ts
+++ b/packages/core/src/lib/util/nested.util.ts
@@ -93,6 +93,25 @@ export function getNestedSlug(
   return '';
 }
 
+export function isNodeEditable(collection: Collection, node: SingleTreeNodeData | TreeNodeData): boolean {
+  return !node.isDir && (!collection.extension || node.path.endsWith(collection.extension));
+}
+
+export function isNodeIndexFile(collection: Collection, node: SingleTreeNodeData | TreeNodeData | Entry): boolean {
+  const index_file = 'nested' in collection ? collection.nested?.path?.index_file : undefined;
+  return !!(
+    index_file && node && 'slug' in node
+    && (!('children' in node) || !node.isDir)
+    && node.path.endsWith(`/${index_file}.${collection.extension}`)
+  );
+}
+
+export function getTreeNodeIndexFile(collection: Collection, node: SingleTreeNodeData | TreeNodeData | Entry): (TreeNodeData & Entry) | undefined {
+  if (node && 'children' in node) {
+    return node.children.find(c => isNodeIndexFile(collection, c)) as TreeNodeData & Entry;
+  }
+}
+
 export function getTreeData<EF extends BaseField>(
   collection: Collection<EF>,
   entries: Entry[],

--- a/tailwind.base.config.js
+++ b/tailwind.base.config.js
@@ -17,15 +17,20 @@ module.exports = {
         "markdown-toolbar": "40px",
       },
       width: {
-        main: "calc(100% - 256px)",
+        main: "calc(100% - 384px)",
         preview: "calc(100% - 450px)",
-        "sidebar-expanded": "256px",
+        "preview-compact-sidebar": "calc(100% - 450px - 384px)",
+        "preview-half-sidebar": "calc((100% - 384px) / 2)",
+        "sidebar-expanded": "384px",
         "sidebar-collapsed": "68px",
-        "editor-only": "640px",
+        "editor-only": "100%",
         "media-library-dialog": "80vw",
         "media-card": "240px",
         "media-preview-image": "126px",
         "image-card": "120px",
+      },
+      inset: {
+        "sidebar-expanded": "384px",
       },
       maxWidth: {
         "media-search": "400px",


### PR DESCRIPTION
## Summary

We shall be able to show all editable elements in the left sidebar and shall not display the separate listing of collection contents (except in very specific cases).

It shall be possible to directly edit the `_index.md` files (ie. directories) without having to find them on the nested collection list.

This PR implements this in a "hacky" way by editing the NestedCollection and breadcrumb links.

## Note

A more invasive and sophisticated solution was tried out (the aim was to avoid having to visibly switch routes), but didn't work properly and started to become quite large (number of lines changes).

To be able to track upstream, the number of modifications must be kept to a minimum.