### PR TITLE
feat: MediaLibrary: filter out collection entry files (documents)

### DIFF
--- a/packages/core/src/actions/mediaLibrary.ts
+++ b/packages/core/src/actions/mediaLibrary.ts
@@ -21,7 +21,7 @@ import {
 import { sanitizeSlug } from '../lib/urlHelper';
 import { basename, getBlobSHA } from '../lib/util';
 import {
-  findCollectionEntryExtensions,
+  filterMediaFilesByExtension,
   selectMediaFilePath,
   selectMediaFilePublicPath,
 } from '../lib/util/media.util';
@@ -159,22 +159,14 @@ export function loadMedia(
       return;
     }
 
-    const entryExtensions = findCollectionEntryExtensions(
-      config.collections,
-      currentFolder || '',
-    ).map(ext => `.${ext}`);
-    const isMediaFile = (file: MediaFile) =>
-      !entryExtensions.length ||
-      ('isDirectory' in file && file.isDirectory) ||
-      !entryExtensions.some(ext => file.name.endsWith(ext));
-
+    const collections = config.collections;
     const backend = currentBackend(config);
     dispatch(mediaLoading(page));
 
     function loadFunction() {
       return backend
         .getMedia(currentFolder, config?.media_library?.folder_support ?? false)
-        .then(files => files.filter(isMediaFile))
+        .then(files => filterMediaFilesByExtension(collections, currentFolder || '', files))
         .then(files => dispatch(mediaLoaded(files)))
         .catch((error: { status?: number }) => {
           console.error(error);

--- a/packages/core/src/actions/mediaLibrary.ts
+++ b/packages/core/src/actions/mediaLibrary.ts
@@ -174,7 +174,7 @@ export function loadMedia(
     function loadFunction() {
       return backend
         .getMedia(currentFolder, config?.media_library?.folder_support ?? false)
-        .then(files => files.filter(file => isMediaFile(file)))
+        .then(files => files.filter(isMediaFile))
         .then(files => dispatch(mediaLoaded(files)))
         .catch((error: { status?: number }) => {
           console.error(error);

--- a/packages/core/src/components/collections/NestedCollection.tsx
+++ b/packages/core/src/components/collections/NestedCollection.tsx
@@ -6,7 +6,12 @@ import { useLocation } from 'react-router-dom';
 
 import useEntries from '@staticcms/core/lib/hooks/useEntries';
 import classNames from '@staticcms/core/lib/util/classNames.util';
-import {getTreeData, getTreeNodeIndexFile, isNodeEditable, isNodeIndexFile} from '@staticcms/core/lib/util/nested.util';
+import {
+  getTreeData,
+  getTreeNodeIndexFile,
+  isNodeEditable,
+  isNodeIndexFile,
+} from '@staticcms/core/lib/util/nested.util';
 import NavLink from '../navbar/NavLink';
 
 import type { Collection, Entry } from '@staticcms/core/interface';
@@ -15,7 +20,9 @@ import type { TreeNodeData } from '@staticcms/core/lib/util/nested.util';
 function getNodeTitle(node: TreeNodeData) {
   const title = node.isRoot
     ? node.title
-    : node.children.find(c => !c.isDir && c.title)?.title || node.title || ('slug' in node && node.slug.split('/').slice(-1)[0]);
+    : node.children.find(c => !c.isDir && c.title)?.title ||
+      node.title ||
+      ('slug' in node && node.slug.split('/').slice(-1)[0]);
   return title;
 }
 
@@ -33,7 +40,6 @@ const TreeNode = ({ collection, treeData, depth = 0, onToggle }: TreeNodeProps) 
   return (
     <>
       {sortedData.map(node => {
-
         if (isNodeIndexFile(collection, node)) {
           return null;
         }

--- a/packages/core/src/components/entry-editor/EditorRoute.tsx
+++ b/packages/core/src/components/entry-editor/EditorRoute.tsx
@@ -28,7 +28,7 @@ const EditorRoute = ({ newRecord = false, collections }: EditorRouteProps) => {
     return <Navigate to={defaultPath} />;
   }
 
-  return <Editor name={name} slug={slug} newRecord={newRecord} showLeftNav/>;
+  return <Editor name={name} slug={slug} newRecord={newRecord} showLeftNav />;
 };
 
 export default EditorRoute;

--- a/packages/core/src/components/entry-editor/editor-preview-pane/EditorPreviewPane.tsx
+++ b/packages/core/src/components/entry-editor/editor-preview-pane/EditorPreviewPane.tsx
@@ -182,7 +182,13 @@ const PreviewPane = (props: TranslatedProps<EditorPreviewPaneProps>) => {
             top-16
             right-0
           `,
-          showLeftNav ? (editorCompact ? 'w-preview-compact-sidebar' : 'w-preview-half-sidebar') : (editorCompact ? 'w-preview' : 'w-6/12'),
+          showLeftNav
+            ? editorCompact
+              ? 'w-preview-compact-sidebar'
+              : 'w-preview-half-sidebar'
+            : editorCompact
+            ? 'w-preview'
+            : 'w-6/12',
         )}
       >
         {!entry || !entry.data ? null : (

--- a/packages/core/src/lib/hooks/useBreadcrumbs.ts
+++ b/packages/core/src/lib/hooks/useBreadcrumbs.ts
@@ -5,7 +5,7 @@ import { useAppDispatch } from '@staticcms/core/store/hooks';
 import { selectEntryCollectionTitle, selectFolderEntryExtension } from '../util/collection.util';
 import { addFileTemplateFields } from '../widgets/stringTemplate';
 import useEntries from './useEntries';
-import {getTreeNodeIndexFile} from "@staticcms/core/lib/util/nested.util";
+import { getTreeNodeIndexFile } from '@staticcms/core/lib/util/nested.util';
 
 import type { Breadcrumb, Collection, Entry } from '@staticcms/core/interface';
 import type { t } from 'react-polyglot';

--- a/packages/core/src/lib/hooks/useMediaFiles.ts
+++ b/packages/core/src/lib/hooks/useMediaFiles.ts
@@ -61,7 +61,7 @@ export default function useMediaFiles(field?: MediaField, currentFolder?: string
             ? trim(currentFolder, '/').replace(trim(media_folder, '/'), public_folder)
             : currentFolder,
         )
-      ).filter(file => isMediaFile(file));
+      ).filter(isMediaFile);
 
       if (alive) {
         setCurrentFolderMediaFiles(files);

--- a/packages/core/src/lib/hooks/useMediaFiles.ts
+++ b/packages/core/src/lib/hooks/useMediaFiles.ts
@@ -8,7 +8,7 @@ import { selectConfig } from '@staticcms/core/reducers/selectors/config';
 import { selectEditingDraft } from '@staticcms/core/reducers/selectors/entryDraft';
 import { selectMediaLibraryFiles } from '@staticcms/core/reducers/selectors/mediaLibrary';
 import { useAppSelector } from '@staticcms/core/store/hooks';
-import { selectMediaFolder } from '../util/media.util';
+import { findCollectionEntryExtensions, selectMediaFolder } from '../util/media.util';
 import useFolderSupport from './useFolderSupport';
 import { fileForEntry } from '../util/collection.util';
 
@@ -40,16 +40,28 @@ export default function useMediaFiles(field?: MediaField, currentFolder?: string
 
     let alive = true;
 
+    const entryExtensions = findCollectionEntryExtensions(
+      config.collections,
+      currentFolder || '',
+    ).map(ext => `.${ext}`);
+    const isMediaFile = (file: MediaFile) =>
+      !entryExtensions.length ||
+      ('isDirectory' in file && file.isDirectory) ||
+      !entryExtensions.some(ext => file.name.endsWith(ext));
+
     const getMediaFiles = async () => {
       const { media_folder, public_folder } = config ?? {};
       const backend = currentBackend(config);
-      const files = await backend.getMedia(
-        currentFolder,
-        folderSupport,
-        public_folder
-          ? trim(currentFolder, '/').replace(trim(media_folder, '/'), public_folder)
-          : currentFolder,
-      );
+
+      const files = (
+        await backend.getMedia(
+          currentFolder,
+          folderSupport,
+          public_folder
+            ? trim(currentFolder, '/').replace(trim(media_folder, '/'), public_folder)
+            : currentFolder,
+        )
+      ).filter(file => isMediaFile(file));
 
       if (alive) {
         setCurrentFolderMediaFiles(files);
@@ -62,7 +74,7 @@ export default function useMediaFiles(field?: MediaField, currentFolder?: string
     return () => {
       alive = false;
     };
-  }, [currentFolder, config, entry, folderSupport]);
+  }, [currentFolder, collection, config, entry, folderSupport]);
 
   const files = useMemo(() => {
     if (!entry || !config) {

--- a/packages/core/src/lib/hooks/useMediaFiles.ts
+++ b/packages/core/src/lib/hooks/useMediaFiles.ts
@@ -8,7 +8,7 @@ import { selectConfig } from '@staticcms/core/reducers/selectors/config';
 import { selectEditingDraft } from '@staticcms/core/reducers/selectors/entryDraft';
 import { selectMediaLibraryFiles } from '@staticcms/core/reducers/selectors/mediaLibrary';
 import { useAppSelector } from '@staticcms/core/store/hooks';
-import { findCollectionEntryExtensions, selectMediaFolder } from '../util/media.util';
+import { filterMediaFilesByExtension, selectMediaFolder } from '../util/media.util';
 import useFolderSupport from './useFolderSupport';
 import { fileForEntry } from '../util/collection.util';
 
@@ -40,28 +40,21 @@ export default function useMediaFiles(field?: MediaField, currentFolder?: string
 
     let alive = true;
 
-    const entryExtensions = findCollectionEntryExtensions(
-      config.collections,
-      currentFolder || '',
-    ).map(ext => `.${ext}`);
-    const isMediaFile = (file: MediaFile) =>
-      !entryExtensions.length ||
-      ('isDirectory' in file && file.isDirectory) ||
-      !entryExtensions.some(ext => file.name.endsWith(ext));
-
     const getMediaFiles = async () => {
       const { media_folder, public_folder } = config ?? {};
       const backend = currentBackend(config);
 
-      const files = (
+      const files = filterMediaFilesByExtension(
+        config.collections,
+        currentFolder || '',
         await backend.getMedia(
           currentFolder,
           folderSupport,
           public_folder
             ? trim(currentFolder, '/').replace(trim(media_folder, '/'), public_folder)
             : currentFolder,
-        )
-      ).filter(isMediaFile);
+        ),
+      );
 
       if (alive) {
         setCurrentFolderMediaFiles(files);

--- a/packages/core/src/lib/util/media.util.ts
+++ b/packages/core/src/lib/util/media.util.ts
@@ -4,6 +4,7 @@ import { dirname } from 'path';
 import { basename, isAbsolutePath } from '.';
 import { folderFormatter } from '../formatters';
 import { joinUrlPath } from '../urlHelper';
+import { selectFolderEntryExtension } from '@staticcms/core/lib/util/collection.util';
 
 import type {
   BaseField,
@@ -350,4 +351,20 @@ export function selectMediaFilePath(
   return mediaPath.startsWith(mediaFolder)
     ? mediaPath
     : joinUrlPath(mediaFolder, basename(mediaPath));
+}
+
+export function findCollectionsByFolder(collections: Collection[], folder: string) {
+  return collections.filter(
+    collection =>
+      !folder ||
+      folder.startsWith(
+        ('folder' in collection && collection.folder) || (collection.path || '').slice(1),
+      ),
+  );
+}
+
+export function findCollectionEntryExtensions(collections: Collection[], folder: string) {
+  return findCollectionsByFolder(collections, folder).map(collection =>
+    selectFolderEntryExtension(collection),
+  );
 }

--- a/packages/core/src/lib/util/media.util.ts
+++ b/packages/core/src/lib/util/media.util.ts
@@ -4,9 +4,11 @@ import { dirname } from 'path';
 import { basename, isAbsolutePath } from '.';
 import { folderFormatter } from '../formatters';
 import { joinUrlPath } from '../urlHelper';
-import { selectFolderEntryExtension } from '@staticcms/core/lib/util/collection.util';
+import { selectFolderEntryExtension } from './collection.util';
 
 import type {
+  ImplementationMediaFile,
+  MediaFile,
   BaseField,
   Collection,
   CollectionFile,
@@ -18,7 +20,7 @@ import type {
   MarkdownField,
   MediaField,
   ObjectField,
-} from '@staticcms/core/interface';
+} from '../../interface';
 
 export const DRAFT_MEDIA_FILES = 'DRAFT_MEDIA_FILES';
 
@@ -366,5 +368,20 @@ export function findCollectionsByFolder(collections: Collection[], folder: strin
 export function findCollectionEntryExtensions(collections: Collection[], folder: string) {
   return findCollectionsByFolder(collections, folder).map(collection =>
     selectFolderEntryExtension(collection),
+  );
+}
+
+export function filterMediaFilesByExtension(
+  collections: Collection[],
+  folder: string,
+  mediaFiles: ImplementationMediaFile[],
+) {
+  const entryExtensions = findCollectionEntryExtensions(collections, folder).map(ext => `.${ext}`);
+
+  return mediaFiles.filter(
+    (file: MediaFile) =>
+      !entryExtensions.length ||
+      ('isDirectory' in file && file.isDirectory) ||
+      !entryExtensions.some(ext => file.name.endsWith(ext)),
   );
 }

--- a/packages/core/src/lib/util/nested.util.ts
+++ b/packages/core/src/lib/util/nested.util.ts
@@ -93,20 +93,31 @@ export function getNestedSlug(
   return '';
 }
 
-export function isNodeEditable(collection: Collection, node: SingleTreeNodeData | TreeNodeData): boolean {
+export function isNodeEditable(
+  collection: Collection,
+  node: SingleTreeNodeData | TreeNodeData,
+): boolean {
   return !node.isDir && (!collection.extension || node.path.endsWith(collection.extension));
 }
 
-export function isNodeIndexFile(collection: Collection, node: SingleTreeNodeData | TreeNodeData | Entry): boolean {
+export function isNodeIndexFile(
+  collection: Collection,
+  node: SingleTreeNodeData | TreeNodeData | Entry,
+): boolean {
   const index_file = 'nested' in collection ? collection.nested?.path?.index_file : undefined;
   return !!(
-    index_file && node && 'slug' in node
-    && (!('children' in node) || !node.isDir)
-    && node.path.endsWith(`/${index_file}.${collection.extension}`)
+    index_file &&
+    node &&
+    'slug' in node &&
+    (!('children' in node) || !node.isDir) &&
+    node.path.endsWith(`/${index_file}.${collection.extension}`)
   );
 }
 
-export function getTreeNodeIndexFile(collection: Collection, node: SingleTreeNodeData | TreeNodeData | Entry): (TreeNodeData & Entry) | undefined {
+export function getTreeNodeIndexFile(
+  collection: Collection,
+  node: SingleTreeNodeData | TreeNodeData | Entry,
+): (TreeNodeData & Entry) | undefined {
   if (node && 'children' in node) {
     return node.children.find(c => isNodeIndexFile(collection, c)) as TreeNodeData & Entry;
   }


### PR DESCRIPTION
## Summary

Most installations of *static-cms* seem to be using a single dedicated media folder or a completely different media library implementation.

We embedd media files close to the documents which use them, thus we shall ignore entry file types (pages, documents) in the media library.

(PR includes a few additional prettifier changes.)