### PR TITLE
feat: NestedCollections: support Hugo branch bundle organization

### DIFF
--- a/packages/core/src/actions/media.ts
+++ b/packages/core/src/actions/media.ts
@@ -95,8 +95,8 @@ export function getAsset<T extends MediaField, EF extends BaseField = UnknownFie
       currentFolder,
     );
 
-    const { asset, isLoading } = state.medias[resolvedPath] || {};
-    if (isLoading) {
+    const { asset, isLoading, error } = state.medias[resolvedPath] || {};
+    if (isLoading || error) {
       return promiseCache[resolvedPath];
     }
 
@@ -105,10 +105,10 @@ export function getAsset<T extends MediaField, EF extends BaseField = UnknownFie
       return Promise.resolve(asset);
     }
 
-    const p = new Promise<AssetProxy>(resolve => {
+    const p = new Promise<AssetProxy>((resolve, reject) => {
       loadAsset(resolvedPath, dispatch, getState).then(asset => {
         resolve(asset);
-      });
+      }).catch(error => reject(error));
     });
 
     promiseCache[resolvedPath] = p;

--- a/packages/core/src/components/common/image/Image.tsx
+++ b/packages/core/src/components/common/image/Image.tsx
@@ -7,6 +7,7 @@ import { isEmpty } from '@staticcms/core/lib/util/string.util';
 import { generateClassNames } from '@staticcms/core/lib/util/theming.util';
 import { selectEditingDraft } from '@staticcms/core/reducers/selectors/entryDraft';
 import { useAppSelector } from '@staticcms/core/store/hooks';
+import {isNodeIndexFile} from "@staticcms/core/lib/util/nested.util";
 
 import type {
   BaseField,
@@ -66,10 +67,21 @@ const Image = <EF extends BaseField = UnknownField>({
 export const withMdxImage = <EF extends BaseField = UnknownField>({
   collection,
   field,
-}: Pick<ImageProps<EF>, 'collection' | 'field'>) => {
-  const MdxImage = (props: Omit<ImageProps<EF>, 'collection' | 'field'>) => (
-    <Image {...props} collection={collection} field={field} />
-  );
+  entry,
+}: Pick<ImageProps<EF>, 'collection' | 'field' | 'entry'>) => {
+  const MdxImage = (props: Omit<ImageProps<EF>, 'collection' | 'field'>) => {
+
+    if (collection?.media_library?.branch_bundle
+      && collection
+      && entry
+      && props.src
+      && props.src.startsWith('../')
+      && !isNodeIndexFile(collection, entry)) {
+      props = {...props, src: props.src.slice(3)};
+    }
+
+    return <Image {...props} collection={collection} field={field} />
+  };
 
   return MdxImage;
 };

--- a/packages/core/src/components/common/image/Image.tsx
+++ b/packages/core/src/components/common/image/Image.tsx
@@ -7,7 +7,7 @@ import { isEmpty } from '@staticcms/core/lib/util/string.util';
 import { generateClassNames } from '@staticcms/core/lib/util/theming.util';
 import { selectEditingDraft } from '@staticcms/core/reducers/selectors/entryDraft';
 import { useAppSelector } from '@staticcms/core/store/hooks';
-import {isNodeIndexFile} from "@staticcms/core/lib/util/nested.util";
+import {rewriteNodeBranchBundleRelativeLinkSrc} from "@staticcms/core/lib/util/nested.util";
 
 import type {
   BaseField,
@@ -69,18 +69,13 @@ export const withMdxImage = <EF extends BaseField = UnknownField>({
   field,
   entry,
 }: Pick<ImageProps<EF>, 'collection' | 'field' | 'entry'>) => {
-  const MdxImage = (props: Omit<ImageProps<EF>, 'collection' | 'field'>) => {
+  const MdxImage = (props: Omit<ImageProps<EF>, 'collection' | 'field' | 'entry'>) => {
 
-    if (collection?.media_library?.branch_bundle
-      && collection
-      && entry
-      && props.src
-      && props.src.startsWith('../')
-      && !isNodeIndexFile(collection, entry)) {
-      props = {...props, src: props.src.slice(3)};
+    if (collection && entry && props.src) {
+      props = {...props, src: rewriteNodeBranchBundleRelativeLinkSrc(collection, entry, props.src)};
     }
 
-    return <Image {...props} collection={collection} field={field} />
+    return <Image {...props} collection={collection} field={field} entry={entry} />
   };
 
   return MdxImage;

--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -583,6 +583,7 @@ export interface MediaLibraryInitOptions {
 export interface MediaLibraryConfig {
   max_file_size?: number;
   folder_support?: boolean;
+  branch_bundle?: boolean;
 }
 
 export type BackendType =

--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -236,6 +236,8 @@ interface Nested {
     label?: string;
     index_file: string;
   };
+
+  branch_bundle?: boolean;
 }
 
 export interface I18nSettings {
@@ -583,7 +585,6 @@ export interface MediaLibraryInitOptions {
 export interface MediaLibraryConfig {
   max_file_size?: number;
   folder_support?: boolean;
-  branch_bundle?: boolean;
 }
 
 export type BackendType =

--- a/packages/core/src/lib/util/media.util.ts
+++ b/packages/core/src/lib/util/media.util.ts
@@ -338,6 +338,9 @@ export function selectMediaFilePath(
     }
 
     if (mediaPathDir.includes(publicFolder) && mediaPathDir != mediaFolder) {
+      const mergableMediaPathDir = mediaFolder === '' || mediaFolder.endsWith('/') || mediaPathDir === '' || mediaPathDir.includes('/')
+        ? mediaPathDir
+        : '/' + mediaPathDir;
       mediaFolder = selectMediaFolder(
         config,
         collection,
@@ -345,7 +348,7 @@ export function selectMediaFilePath(
         field,
         publicFolder === '' && mediaPathDir.startsWith(mediaFolder)
           ? mediaPathDir
-          : mediaPathDir.replace(publicFolder, mediaFolder),
+          : mergableMediaPathDir.replace(publicFolder, mediaFolder),
       );
     }
   }

--- a/packages/core/src/lib/util/nested.util.ts
+++ b/packages/core/src/lib/util/nested.util.ts
@@ -6,7 +6,7 @@ import { stringTemplate } from '../widgets';
 import { selectEntryCollectionTitle, selectFolderEntryExtension } from './collection.util';
 import { isEmpty, isNotEmpty } from './string.util';
 
-import type { BaseField, Collection, Entry, Slug } from '@staticcms/core/interface';
+import type { BaseField, Collection, Entry, Slug, UnknownField } from '@staticcms/core/interface';
 
 const { addFileTemplateFields } = stringTemplate;
 
@@ -93,15 +93,15 @@ export function getNestedSlug(
   return '';
 }
 
-export function isNodeEditable(
-  collection: Collection,
+export function isNodeEditable<EF extends BaseField = UnknownField>(
+  collection: Collection<EF>,
   node: SingleTreeNodeData | TreeNodeData,
 ): boolean {
   return !node.isDir && (!collection.extension || node.path.endsWith(collection.extension));
 }
 
-export function isNodeIndexFile(
-  collection: Collection,
+export function isNodeIndexFile<EF extends BaseField = UnknownField>(
+  collection: Collection<EF>,
   node: SingleTreeNodeData | TreeNodeData | Entry,
 ): boolean {
   const index_file = 'nested' in collection ? collection.nested?.path?.index_file : undefined;
@@ -114,8 +114,8 @@ export function isNodeIndexFile(
   );
 }
 
-export function getTreeNodeIndexFile(
-  collection: Collection,
+export function getTreeNodeIndexFile<EF extends BaseField = UnknownField>(
+  collection: Collection<EF>,
   node: SingleTreeNodeData | TreeNodeData | Entry,
 ): (TreeNodeData & Entry) | undefined {
   if (node && 'children' in node) {

--- a/packages/core/src/lib/util/nested.util.ts
+++ b/packages/core/src/lib/util/nested.util.ts
@@ -114,6 +114,20 @@ export function isNodeIndexFile<EF extends BaseField = UnknownField>(
   );
 }
 
+export function rewriteNodeBranchBundleRelativeLinkSrc<EF extends BaseField = UnknownField>(
+  collection: Collection<EF>,
+  node: SingleTreeNodeData | TreeNodeData | Entry,
+  src: string,
+): string {
+  if (collection.media_library?.branch_bundle
+    && src.startsWith('../')  // we ignore impossible relative links inside the created directory
+    && !isNodeIndexFile(collection, node)) {
+    return src.slice(3);
+  }
+
+  return src;
+}
+
 export function getTreeNodeIndexFile<EF extends BaseField = UnknownField>(
   collection: Collection<EF>,
   node: SingleTreeNodeData | TreeNodeData | Entry,

--- a/packages/core/src/lib/util/nested.util.ts
+++ b/packages/core/src/lib/util/nested.util.ts
@@ -119,7 +119,7 @@ export function rewriteNodeBranchBundleRelativeLinkSrc<EF extends BaseField = Un
   node: SingleTreeNodeData | TreeNodeData | Entry,
   src: string,
 ): string {
-  if (collection.media_library?.branch_bundle
+  if ('nested' in collection && collection.nested?.branch_bundle
     && src.startsWith('../')  // we ignore impossible relative links inside the created directory
     && !isNodeIndexFile(collection, node)) {
     return src.slice(3);

--- a/packages/core/src/widgets/markdown/MarkdownPreview.tsx
+++ b/packages/core/src/widgets/markdown/MarkdownPreview.tsx
@@ -43,14 +43,14 @@ const MdxComponent: FC<MdxComponentProps> = ({ state }) => {
 };
 
 const MarkdownPreview: FC<WidgetPreviewProps<string, MarkdownField>> = previewProps => {
-  const { value, collection, field } = previewProps;
+  const { value, collection, field, entry } = previewProps;
 
   const id = useUUID();
 
   const components = useMemo(
     () => ({
       Shortcode: withShortcodeMdxComponent({ previewProps }),
-      img: withMdxImage({ collection, field }),
+      img: withMdxImage({ collection, field, entry }),
     }),
     [collection, field, previewProps],
   );

--- a/packages/core/src/widgets/markdown/plate/PlateEditor.tsx
+++ b/packages/core/src/widgets/markdown/plate/PlateEditor.tsx
@@ -157,6 +157,7 @@ const PlateEditor: FC<PlateEditorProps> = ({
       [ELEMENT_CODE_BLOCK]: CodeBlockElement,
       [ELEMENT_LINK]: withLinkElement({
         collection,
+        entry,
         field,
       }),
       [ELEMENT_IMAGE]: withImageElement({

--- a/packages/core/src/widgets/markdown/plate/components/nodes/image/withImageElement.tsx
+++ b/packages/core/src/widgets/markdown/plate/components/nodes/image/withImageElement.tsx
@@ -19,6 +19,7 @@ import type { MdImageElement, MdValue } from '@staticcms/markdown';
 import type { PlateRenderElementProps } from '@udecode/plate';
 import type { TMediaElement } from '@udecode/plate-media';
 import type { FC } from 'react';
+import {rewriteNodeBranchBundleRelativeLinkSrc} from "@staticcms/core/lib/util/nested.util";
 
 export interface WithImageElementProps {
   collection: Collection<MarkdownField>;
@@ -93,7 +94,11 @@ const withImageElement = ({ collection, entry, field }: WithImageElementProps) =
       setAnchorEl(null);
     }, []);
 
-    const assetSource = useMediaAsset(url, collection, field, entry);
+    let loadUrl = url;
+    if (collection && entry && url) {
+      loadUrl = rewriteNodeBranchBundleRelativeLinkSrc(collection, entry, url);
+    }
+    const assetSource = useMediaAsset(loadUrl, collection, field, entry);
 
     const handleMediaChange = useCallback(
       (newValue: MediaPath<string>) => {
@@ -177,7 +182,7 @@ const withImageElement = ({ collection, entry, field }: WithImageElementProps) =
           anchorEl={anchorEl}
           collection={collection}
           field={field}
-          url={url}
+          url={loadUrl}
           text={alt}
           onMediaChange={handleMediaChange}
           onRemove={handleRemove}

--- a/packages/core/src/widgets/markdown/plate/components/nodes/link/withLinkElement.tsx
+++ b/packages/core/src/widgets/markdown/plate/components/nodes/link/withLinkElement.tsx
@@ -14,6 +14,7 @@ import { useFocused } from 'slate-react';
 import useDebounce from '@staticcms/core/lib/hooks/useDebounce';
 import { generateClassNames } from '@staticcms/core/lib/util/theming.util';
 import MediaPopover from '../../common/MediaPopover';
+import {rewriteNodeBranchBundleRelativeLinkSrc} from "@staticcms/core/lib/util/nested.util";
 
 import type { Collection, MarkdownField, MediaPath } from '@staticcms/core/interface';
 import type { MdLinkElement, MdValue } from '@staticcms/markdown';
@@ -26,10 +27,11 @@ const classes = generateClassNames('WidgetMarkdown_Link', ['root']);
 
 export interface WithLinkElementProps {
   collection: Collection<MarkdownField>;
+  entry: Entry;
   field: MarkdownField;
 }
 
-const withLinkElement = ({ collection, field }: WithLinkElementProps) => {
+const withLinkElement = ({ collection, entry, field }: WithLinkElementProps) => {
   const LinkElement: FC<PlateRenderElementProps<MdValue, MdLinkElement>> = ({
     attributes: { ref: _ref, ...attributes },
     children,
@@ -198,12 +200,17 @@ const withLinkElement = ({ collection, field }: WithLinkElementProps) => {
       anchorEl,
     ]);
 
+    let loadUrl = url;
+    if (collection && entry && url) {
+      loadUrl = rewriteNodeBranchBundleRelativeLinkSrc(collection, entry, url);
+    }
+
     return (
       <span onBlur={handleBlur}>
         <a
           ref={urlRef}
           {...attributes}
-          href={url}
+          href={loadUrl}
           {...nodeProps}
           onClick={handleClick}
           className={classes.root}
@@ -214,7 +221,7 @@ const withLinkElement = ({ collection, field }: WithLinkElementProps) => {
           anchorEl={anchorEl}
           collection={collection}
           field={field}
-          url={url}
+          url={loadUrl}
           text={alt}
           onMediaChange={handleMediaChange}
           onRemove={handleRemove}

--- a/packages/docs/content/docs/collection-types.mdx
+++ b/packages/docs/content/docs/collection-types.mdx
@@ -599,6 +599,8 @@ collections:
       # adding a path object allows editing the path of entries
       # moving an existing entry will move the entire sub tree of the entry to the new location
       path: { widget: string, index_file: 'index' }
+      # support for Hugo's branch bundles, with index files named _index.md (disabled by default)
+      branch_bundle: false
     fields:
       - label: Title
         name: title
@@ -624,6 +626,7 @@ collections:
           "label": "Path",
           "index_file": "index"
         }
+        "branch_bundle": false
       },
       "fields": [
         {
@@ -658,6 +661,31 @@ content
         ├── hello-world
         │   └── index.md
         └── index.md
+```
+
+#### Hugo Branch Bundles
+
+The [Hugo](https://gohugo.io/) static site generator supports a page organization model called [branch bundles](https://gohugo.io/content-management/page-bundles/#branch-bundles).
+
+Under branch bundles, index files are called `_index.md` and sibling markdown files are *rendered* into their own nested directory.
+
+To support branch bundle organization with a specific nested collection, set the `branch_bundle` option to `true`.
+
+A branch bundles enabled folder structure may looks like this:
+
+```bash
+content
+└── pages
+    ├── world
+    │   ├── res
+    │   │   └── hello-world.jpg
+    │   ├── hello-world.md
+    │   └── _index.md
+    ├── team
+    │   ├── john.jpg
+    │   ├── john.md
+    │   └── _index.md
+    └── _index.md
 ```
 
 ## File Collections

--- a/packages/docs/content/docs/configuration-options.mdx
+++ b/packages/docs/content/docs/configuration-options.mdx
@@ -132,7 +132,6 @@ The `media_library` settings allows customization of the media library.
 | -------------- | ------- | -------- | -------------------------------------------------------------------------------------- |
 | max_file_size  | number  | `512000` | _Optional_. <BetaImage /> The max size, in bytes, of files that can be uploaded to the media library |
 | folder_support | boolean | `false`  | _Optional_. <BetaImage /> Enables directory navigation and folder creation in your media library     |
-| branch_bundle  | boolean | `false`  | _Optional_. <BetaImage /> Enables lookup of media on nested pages organized after Hugo's [branch bundle](https://gohugo.io/content-management/page-bundles/#branch-bundles) style |
 
 ### Example
 

--- a/packages/docs/content/docs/configuration-options.mdx
+++ b/packages/docs/content/docs/configuration-options.mdx
@@ -132,6 +132,7 @@ The `media_library` settings allows customization of the media library.
 | -------------- | ------- | -------- | -------------------------------------------------------------------------------------- |
 | max_file_size  | number  | `512000` | _Optional_. <BetaImage /> The max size, in bytes, of files that can be uploaded to the media library |
 | folder_support | boolean | `false`  | _Optional_. <BetaImage /> Enables directory navigation and folder creation in your media library     |
+| branch_bundle  | boolean | `false`  | _Optional_. <BetaImage /> Enables lookup of media on nested pages organized after Hugo's [branch bundle](https://gohugo.io/content-management/page-bundles/#branch-bundles) style |
 
 ### Example
 


### PR DESCRIPTION
## Summary

Hugo supports an organization style called [branch bundles](https://gohugo.io/content-management/page-bundles/#branch-bundles).

This style causes additional markdown files in a page directory to be rendered inside additional child directories.

Relative links on those sibling pages must assume the working directory is inside that child directory created by Hugo.

Static CMS can't currently handle this style of organizing pages and thus was incompatible with Hugo setups which use it.

## Implementation

Presence of branch bundle organization can't be auto-detected since `index_file` names are configurable in Static CMS and could be `_index` (note the underscore) for any other reason.

Thus this PR adds a new flag `nested.branch_bundle` to indicate, on a per collection level, that branch bundle organization is used.