### PR TITLE
feat: display working QuickCreate on EditorRoute

### DIFF
--- a/packages/core/src/components/MainView.tsx
+++ b/packages/core/src/components/MainView.tsx
@@ -38,6 +38,7 @@ interface MainViewProps {
   noScroll?: boolean;
   children: ReactNode;
   collection?: Collection;
+  slug?: string;
 }
 
 const MainView = ({
@@ -49,6 +50,7 @@ const MainView = ({
   noScroll = false,
   navbarActions,
   collection,
+  slug,
 }: MainViewProps) => {
   return (
     <>
@@ -56,6 +58,8 @@ const MainView = ({
         breadcrumbs={breadcrumbs}
         showQuickCreate={showQuickCreate}
         navbarActions={navbarActions}
+        collection={collection}
+        slug={slug}
       />
       <div className={classes.root}>
         {showLeftNav ? <Sidebar /> : null}

--- a/packages/core/src/components/collections/CollectionPage.tsx
+++ b/packages/core/src/components/collections/CollectionPage.tsx
@@ -44,7 +44,6 @@ const SingleCollectionPage: FC<SingleCollectionPageProps> = ({
   return (
     <MainView
       breadcrumbs={breadcrumbs}
-      collection={collection}
       showQuickCreate
       showLeftNav
       noScroll

--- a/packages/core/src/components/entry-editor/EditorInterface.tsx
+++ b/packages/core/src/components/entry-editor/EditorInterface.tsx
@@ -447,6 +447,9 @@ const EditorInterface = ({
       breadcrumbs={breadcrumbs}
       noMargin
       showLeftNav={true}
+      showQuickCreate
+      collection={collection}
+      slug={slug}
       noScroll={finalPreviewActive || i18nActive}
       navbarActions={
         <EditorToolbar

--- a/packages/core/src/components/navbar/Navbar.tsx
+++ b/packages/core/src/components/navbar/Navbar.tsx
@@ -14,7 +14,7 @@ import BranchSelect from './BranchSelect';
 import QuickCreate from './QuickCreate';
 import SettingsDropdown from './SettingsDropdown';
 
-import type { Breadcrumb, TranslatedProps } from '@staticcms/core/interface';
+import type { Breadcrumb, Collection, TranslatedProps } from '@staticcms/core/interface';
 import type { FC, ReactNode } from 'react';
 
 import './Navbar.css';
@@ -39,12 +39,16 @@ export interface NavbarProps {
   breadcrumbs?: Breadcrumb[];
   showQuickCreate?: boolean;
   navbarActions?: ReactNode;
+  collection?: Collection;
+  slug?: string;
 }
 
 const Navbar = ({
   showQuickCreate = false,
   navbarActions = null,
   breadcrumbs = [],
+  collection,
+  slug,
 }: TranslatedProps<NavbarProps>) => {
   const dispatch = useAppDispatch();
   const config = useAppSelector(selectConfig);
@@ -92,7 +96,7 @@ const Navbar = ({
             ) : null}
             <BranchSelect />
             {showQuickCreate ? (
-              <QuickCreate key="quick-create" rootClassName={classes['quick-create']} />
+              <QuickCreate key="quick-create" collection={collection} slug={slug} rootClassName={classes['quick-create']} />
             ) : null}
             {navbarActions}
             <SettingsDropdown inEditor={inEditor} />

--- a/packages/core/src/components/navbar/QuickCreate.tsx
+++ b/packages/core/src/components/navbar/QuickCreate.tsx
@@ -8,18 +8,27 @@ import { useAppSelector } from '@staticcms/core/store/hooks';
 import Menu from '../common/menu/Menu';
 import MenuGroup from '../common/menu/MenuGroup';
 import MenuItemLink from '../common/menu/MenuItemLink';
+import { customPathFromSlug } from "@staticcms/core/lib/util/nested.util";
 
-import type { TranslatedProps } from '@staticcms/core/interface';
+import type { Collection, TranslatedProps } from '@staticcms/core/interface';
 import type { FC } from 'react';
 import type { MenuProps } from '../common/menu/Menu';
 
-export type QuickCreateProps = Pick<
+export interface QuickCreateProps extends Pick<
   MenuProps,
   'rootClassName' | 'buttonClassName' | 'hideDropdownIcon' | 'hideLabel' | 'variant'
->;
+> {
+  collection?: Collection;
+  slug?: string;
+}
 
-const QuickCreate: FC<TranslatedProps<QuickCreateProps>> = ({ t, ...menuProps }) => {
+const QuickCreate: FC<TranslatedProps<QuickCreateProps>> = ({ t, collection, slug, ...menuProps }) => {
   const collections = useAppSelector(selectCollections);
+
+  const nestedFieldPath = useMemo(
+    () => (collection && slug) ? customPathFromSlug(collection, slug) : '',
+    [collection, slug],
+  );
 
   const createableCollections = useMemo(
     () =>
@@ -38,7 +47,7 @@ const QuickCreate: FC<TranslatedProps<QuickCreateProps>> = ({ t, ...menuProps })
     >
       <MenuGroup>
         {createableCollections.map(collection => (
-          <MenuItemLink key={collection.name} href={getNewEntryUrl(collection.name)}>
+          <MenuItemLink key={collection.name} href={getNewEntryUrl(collection.name, nestedFieldPath)}>
             {collection.label_singular || collection.label}
           </MenuItemLink>
         ))}

--- a/packages/core/src/lib/hooks/useNewEntryUrl.ts
+++ b/packages/core/src/lib/hooks/useNewEntryUrl.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 
 import { getNewEntryUrl } from '../urlHelper';
-import { isNotEmpty } from '../util/string.util';
 
 import type { Collection } from '@staticcms/core/interface';
 
@@ -15,7 +14,7 @@ export default function useNewEntryUrl(
     }
 
     return 'fields' in collection && collection.create
-      ? `${getNewEntryUrl(collection.name)}${isNotEmpty(filterTerm) ? `/${filterTerm}` : ''}`
+      ? `${getNewEntryUrl(collection.name, filterTerm || '')}`
       : '';
   }, [collection, filterTerm]);
 }

--- a/packages/core/src/lib/urlHelper.ts
+++ b/packages/core/src/lib/urlHelper.ts
@@ -8,6 +8,8 @@ import sanitizeFilename from 'sanitize-filename';
 import url from 'url';
 import urlJoin from 'url-join';
 
+import { isNotEmpty } from "@staticcms/core/lib/util/string.util";
+
 import type { Slug } from '../interface';
 
 function getUrl(urlString: string, direct?: boolean) {
@@ -18,8 +20,8 @@ export function getCollectionUrl(collectionName: string, direct?: boolean) {
   return getUrl(`/collections/${collectionName}`, direct);
 }
 
-export function getNewEntryUrl(collectionName: string, direct?: boolean) {
-  return getUrl(`/collections/${collectionName}/new`, direct);
+export function getNewEntryUrl(collectionName: string, folder: string, direct?: boolean) {
+  return getUrl(`/collections/${collectionName}/new${isNotEmpty(folder) ? `/${folder}` : ''}`, direct);
 }
 
 export function addParams(urlString: string, params: Record<string, string>) {


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/28613

## Summary

Display a working `QuickCreate` button in the `NavBar` while editing items in a `Collection`.

Also support adding entries to a `NestedCollection`.