### PR TITLE
NestedCollection: Lazy-load entries

### DIFF
--- a/packages/core/src/backends/github/implementation.tsx
+++ b/packages/core/src/backends/github/implementation.tsx
@@ -248,7 +248,7 @@ export default class GitHub implements BackendClass {
     return { cursor, files: pageFiles };
   };
 
-  async entriesByFolder(folder: string, extension: string, depth: number) {
+  async entriesByFolder(folder: string, extension: string, depth: number, lazyLoadPredicate?: (path: string) => boolean) {
     const repoURL = this.api!.originRepoURL;
 
     let cursor: Cursor;
@@ -258,7 +258,7 @@ export default class GitHub implements BackendClass {
         repoURL,
         depth,
       }).then(files => {
-        const filtered = files.filter(file => filterByExtension(file, extension));
+        const filtered = files.filter(file => filterByExtension(file, extension) && (!lazyLoadPredicate || lazyLoadPredicate(file.path)));
         const result = this.getCursorAndFiles(filtered, 1);
         cursor = result.cursor;
         return result.files;
@@ -279,7 +279,8 @@ export default class GitHub implements BackendClass {
     return files;
   }
 
-  async allEntriesByFolder(folder: string, extension: string, depth: number, pathRegex?: RegExp) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async allEntriesByFolder(folder: string, extension: string, depth: number, pathRegex?: RegExp, lazyLoadPredicate?: (path: string) => boolean) {
     const repoURL = this.api!.originRepoURL;
 
     const listFiles = () =>
@@ -288,7 +289,7 @@ export default class GitHub implements BackendClass {
         depth,
       }).then(files =>
         files.filter(
-          file => (!pathRegex || pathRegex.test(file.path)) && filterByExtension(file, extension),
+          file => (!pathRegex || pathRegex.test(file.path)) && filterByExtension(file, extension) && (!lazyLoadPredicate || lazyLoadPredicate(file.path)),
         ),
       );
 

--- a/packages/core/src/components/collections/entries/EntriesCollection.tsx
+++ b/packages/core/src/components/collections/entries/EntriesCollection.tsx
@@ -71,6 +71,7 @@ const EntriesCollection = ({
 
   const [prevReadyToLoad, setPrevReadyToLoad] = useState(false);
   const [prevCollection, setPrevCollection] = useState(collection);
+  const [prevFilterTerm, setPrevFilterTerm] = useState<string | null>(null);
 
   const groups = useGroups(collection.name);
 
@@ -90,14 +91,17 @@ const EntriesCollection = ({
       collection &&
       !entriesLoaded &&
       readyToLoad &&
-      (!prevReadyToLoad || prevCollection !== collection)
+      (!prevReadyToLoad || prevCollection !== collection) &&
+      (!prevFilterTerm || prevFilterTerm !== filterTerm)
     ) {
-      dispatch(loadEntries(collection));
+      console.log("loadEntriese() EntriesCollection");
+      dispatch(loadEntries(collection, filterTerm || null));
     }
 
     setPrevReadyToLoad(readyToLoad);
     setPrevCollection(collection);
-  }, [collection, dispatch, entriesLoaded, prevCollection, prevReadyToLoad, readyToLoad]);
+    setPrevFilterTerm(filterTerm || null);
+  }, [collection, dispatch, entriesLoaded, prevCollection, prevReadyToLoad, prevFilterTerm, filterTerm, readyToLoad]);
 
   const handleCursorActions = useCallback(
     (action: string) => {

--- a/packages/core/src/components/collections/entries/EntriesCollection.tsx
+++ b/packages/core/src/components/collections/entries/EntriesCollection.tsx
@@ -91,7 +91,7 @@ const EntriesCollection = ({
       collection &&
       !entriesLoaded &&
       readyToLoad &&
-      (!prevReadyToLoad || prevCollection !== collection) &&
+      (!prevCollection || prevCollection !== collection) &&
       (!prevFilterTerm || prevFilterTerm !== filterTerm)
     ) {
       console.log("loadEntriese() EntriesCollection");

--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -239,6 +239,7 @@ interface Nested {
   };
 
   branch_bundle?: boolean;
+  lazy_load?: boolean;
 }
 
 export interface I18nSettings {
@@ -540,6 +541,7 @@ export abstract class BackendClass {
     folder: string,
     extension: string,
     depth: number,
+    lazyLoadPredicate?: (path: string) => boolean,
   ): Promise<ImplementationEntry[]>;
   abstract entriesByFiles(files: ImplementationFile[]): Promise<ImplementationEntry[]>;
 
@@ -562,6 +564,7 @@ export abstract class BackendClass {
     extension: string,
     depth: number,
     pathRegex?: RegExp,
+    lazyLoadPredicate?: (path: string) => boolean,
   ): Promise<ImplementationEntry[]>;
   abstract traverseCursor(
     cursor: Cursor,

--- a/packages/core/src/lib/hooks/useBreadcrumbs.ts
+++ b/packages/core/src/lib/hooks/useBreadcrumbs.ts
@@ -26,8 +26,7 @@ export default function useBreadcrumbs(
   const [prevFilterTerm, setPrevFilterTerm] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!entries || entries.length === 0 || (!prevFilterTerm || prevFilterTerm !== filterTerm)
-    ) {
+    if (!prevFilterTerm || prevFilterTerm !== filterTerm) {
       dispatch(loadEntries(collection, filterTerm || null));
     }
 

--- a/packages/core/src/lib/hooks/useBreadcrumbs.ts
+++ b/packages/core/src/lib/hooks/useBreadcrumbs.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import {useEffect, useMemo, useState} from 'react';
 
 import { loadEntries } from '@staticcms/core/actions/entries';
 import { useAppDispatch } from '@staticcms/core/store/hooks';
@@ -23,13 +23,17 @@ export default function useBreadcrumbs(
 ) {
   const entries = useEntries(collection);
   const dispatch = useAppDispatch();
+  const [prevFilterTerm, setPrevFilterTerm] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!entries || entries.length === 0) {
-      dispatch(loadEntries(collection));
+    if (!entries || entries.length === 0 || (!prevFilterTerm || prevFilterTerm !== filterTerm)
+    ) {
+      dispatch(loadEntries(collection, filterTerm || null));
     }
+
+    setPrevFilterTerm(filterTerm || null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [prevFilterTerm, filterTerm]);
 
   return useMemo(() => {
     const crumbs: Breadcrumb[] = [

--- a/packages/core/src/lib/util/nested.util.ts
+++ b/packages/core/src/lib/util/nested.util.ts
@@ -56,10 +56,8 @@ export function customPathFromSlug(collection: Collection, slug: string): string
     return '';
   }
 
-  if (collection.nested.path) {
-    if ('nested' in collection && collection.nested?.path) {
-      return slug.replace(new RegExp(`/${collection.nested.path.index_file}$`, 'g'), '');
-    }
+  if ('nested' in collection && collection.nested?.path) {
+    return slug.replace(new RegExp(`/${collection.nested.path.index_file}$`, 'g'), '');
   }
 
   return slug;

--- a/packages/docs/content/docs/collection-types.mdx
+++ b/packages/docs/content/docs/collection-types.mdx
@@ -601,6 +601,8 @@ collections:
       path: { widget: string, index_file: 'index' }
       # support for Hugo's branch bundles, with index files named _index.md (disabled by default)
       branch_bundle: false
+      # enable lazy loading of nested collections (disabled by default, experimental)
+      lazy_load: false
     fields:
       - label: Title
         name: title
@@ -627,6 +629,7 @@ collections:
           "index_file": "index"
         }
         "branch_bundle": false
+        "lazy_load": false
       },
       "fields": [
         {
@@ -670,6 +673,8 @@ The [Hugo](https://gohugo.io/) static site generator supports a page organizatio
 Under branch bundles, index files are called `_index.md` and sibling markdown files are *rendered* into their own nested directory.
 
 To support branch bundle organization with a specific nested collection, set the `branch_bundle` option to `true`.
+
+For larger sites with nested collection(s) the experimental `lazy_load` option may be set to `true` to avoid loading unreachable entries.
 
 A branch bundles enabled folder structure may looks like this:
 


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/28898

### Summary

Fix severe performance issues with `NestedCollection`s due to loading the whole file hierarchy.

**NOTES:**
- This is pretty much a nice hack and only works for the GitHub backend, right now.
- There are some open questions/untested corners around moving folder hierarchies (something that we don't support in the UI, right now).
