### PR TITLE
fix: fix endless loop caused by loadBranches() and >30 branches

### DIFF
--- a/packages/core/src/actions/branches.ts
+++ b/packages/core/src/actions/branches.ts
@@ -49,10 +49,12 @@ export function loadBranches() {
     try {
       const branches = await gitHubBackend.getBranches();
 
+      const currentBranch = gitHubBackend.branch;
+      const defaultBranch = 'main';
+
       // if the current branch is not in the list of branches, switch to the default branch
-      if (!branches.find((b) => b.name === gitHubBackend.branch)) {
-        const defaultBranch = 'main';
-        console.info(`[StaticCMS] Branch ${gitHubBackend.branch} not found: switching to ${defaultBranch}`);
+      if (currentBranch !== defaultBranch && !branches.find((b) => b.name === currentBranch)) {
+        console.info(`[StaticCMS] Branch ${currentBranch} not found: switching to ${defaultBranch}`);
         switchBranch(defaultBranch);
       } else {
         dispatch(branchesLoaded(branches));

--- a/packages/core/src/backends/github/API.ts
+++ b/packages/core/src/backends/github/API.ts
@@ -508,7 +508,7 @@ export default class API {
   }
 
   async getBranches() {
-    const result: ReposGetBranchesResponse = await this.request(`${this.originRepoURL}/branches`);
+    const result: ReposGetBranchesResponse = await this.request(`${this.originRepoURL}/branches?per_page=100`);
     return result;
   }
 


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/29109

### Summary

- Set `per_page=100` (maximum permitted page size by API) in `getBranches()`
- Do not call `switchBranch()` if the selected branch is already equal to the default branch (`main`), we have no strategy to solve such a situation, anyways.

### Possible Improvement

We should probably use the configured branch one from the original config file, instead of a hard-coded "default branch".

However, due to the way we currently pass in the `branch=` query parameter, this could be tricky to implement.
